### PR TITLE
Docs improvements

### DIFF
--- a/cubist-cli/src/cli.rs
+++ b/cubist-cli/src/cli.rs
@@ -39,7 +39,7 @@ pub enum Commands {
         /// Directory where to create project
         #[clap(long = "dir", value_parser, value_hint = clap::ValueHint::DirPath)]
         dir: Option<PathBuf>,
-        /// Force creation (e.g., by overwrite existing files or ignoring non-standard templates)
+        /// Force creation (e.g., by overwriting existing files or ignoring non-standard templates)
         #[clap(long, action, default_value = "false")]
         force: bool,
         /// Branch to pull from, if creating a project from template

--- a/cubist-cli/src/commands/compile.rs
+++ b/cubist-cli/src/commands/compile.rs
@@ -57,7 +57,7 @@ fn compile_solc_files(config: &Config) -> Result<()> {
 
         let target_project = TargetProjectInfo::new(config, target)?;
 
-        // Only Solc supported at the moment
+        // Only Solc is supported at the moment
         if target_project.compiler != Compiler::Solc {
             continue;
         }

--- a/cubist-cli/src/commands/new.rs
+++ b/cubist-cli/src/commands/new.rs
@@ -14,7 +14,7 @@ use cubist_config::ProjType;
 /// * `name`  - Project name
 /// * `type_` - Project type/language
 /// * `dir`   - Directory to create the project in
-/// * `force` - Force overwrite existing configuration if one exists
+/// * `force` - Force overwrites existing configuration if one exists
 pub fn empty(name: &str, type_: ProjType, dir: &Path, force: bool) -> Result<()> {
     println!(
         "{} new {} project {} in {}",

--- a/cubist-cli/src/commands/pre_compile.rs
+++ b/cubist-cli/src/commands/pre_compile.rs
@@ -205,7 +205,7 @@ impl PreCompiler {
     }
 
     /// Attempts to compile the original source files. This ensures that the later steps in our
-    /// compilation process deal with sane source files.
+    /// compilation process deals with sane source files.
     pub fn validate_solidity_source_files(
         compiler_config: &CompilerConfig,
         contracts: &ContractsConfig,

--- a/cubist-cli/src/commands/relayer.rs
+++ b/cubist-cli/src/commands/relayer.rs
@@ -343,7 +343,7 @@ impl<M: Middleware + 'static> Relayer<M> {
     /// # Returns
     ///
     /// A future that completes when all necessary bridges are spun up
-    /// (i.e., when they have already regestered listeners for all
+    /// (i.e., when they have already registered listeners for all
     /// events of interest).
     async fn bridges_for_deployment(
         &mut self,

--- a/cubist-node-sdk/README.md
+++ b/cubist-node-sdk/README.md
@@ -10,7 +10,7 @@ With Cubist, you write contracts as if they were all going to be deployed on
 the same chain.  This means you can have a contract directly call a method on
 another contract, as if they were on the same chain. You don't need to commit
 to the chain you're going to deploy a contract to in advance nor clutter your
-code with low-level, error-prone message passing code. Instead, with Cubist,
+code with low-level, error-prone message-passing code. Instead, with Cubist,
 you specify your deployment plan in a [config file][CubistConfig] by mapping
 contract source files to target chains.
 
@@ -148,8 +148,8 @@ Then let's create two solidity files in the `contracts` directory:
     }
     ```
 
-Let's also say we want deploy `Receiver` to Ethereum and the `Sender` to
-Polygon. To do this, we to need update the `contracts` build and deployment
+Let's also say we want to deploy `Receiver` to Ethereum and the `Sender` to
+Polygon. To do this, we need to update the `contracts` build and deployment
 plan in `cubst-config.json`:
 
 ```json


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.